### PR TITLE
Add qtwebkit dependency

### DIFF
--- a/Formula/qgis3-dev.rb
+++ b/Formula/qgis3-dev.rb
@@ -29,6 +29,7 @@ class Qgis3Dev < Formula
   # option "with-qt-mysql", "Build extra Qt MySQL plugin for eVis plugin"
   option "with-qspatialite", "Build QSpatialite Qt database driver"
   option "with-api-docs", "Build the API documentation with Doxygen and Graphviz"
+  option "without-qt-webkit", "Build without webkit based functionality"
 
   depends_on NoQt4Requirement
 
@@ -56,6 +57,9 @@ class Qgis3Dev < Formula
   depends_on "fcgi" if build.with? "server"
   # use newer postgresql client than Apple's, also needed by `psycopg2`
   depends_on "postgresql" => :recommended
+  if build.with? "qt-webkit"
+    depends_on "osgeo/osgeo4mac/qt5-webkit"
+  end
 
   # core providers
   depends_on "osgeo/osgeo4mac/gdal2" # keg_only
@@ -131,7 +135,6 @@ class Qgis3Dev < Formula
       -DQGIS_MACAPP_DEV_PREFIX='#{dev_fw}'
       -DQGIS_MACAPP_INSTALL_DEV=TRUE
       -DWITH_QWTPOLAR=TRUE
-      -DWITH_QTWEBKIT=TRUE
       -DWITH_INTERNAL_QWTPOLAR=FALSE
       -DWITH_ASTYLE=FALSE
       -DWITH_QSCIAPI=FALSE
@@ -159,6 +162,10 @@ class Qgis3Dev < Formula
     args << "-DSPATIALINDEX_INCLUDE_DIR=#{Formula["spatialindex"].opt_include}/spatialindex"
     args << "-DSPATIALITE_INCLUDE_DIR=#{Formula["libspatialite"].opt_include}"
     args << "-DSQLITE3_INCLUDE_DIR=#{Formula["sqlite"].opt_include}"
+
+    if !build.with? "qt-webkit"
+      args << "-DWITH_QTWEBKIT=FALSE"
+    end
 
     args << "-DWITH_SERVER=#{build.with?("server") ? "TRUE" : "FALSE"}"
     if build.with? "server"


### PR DESCRIPTION
The formula currently doesn't compile out of the box because of a missing webkit dependency.

Unfortunately I still have some issues (tried `--without-qt-webkit` now but I think they are unrelated) 

```
cd /tmp/qgis3-dev-20161201-31440-ndvdr6/build && /usr/local/Cellar/cmake/3.7.1/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/qgis3-dev-20161201-31440-ndvdr6 /tmp/qgis3-dev-20161201-31440-ndvdr6/tests/src/gui /tmp/qgis3-dev-20161201-31440-ndvdr6/build /tmp/qgis3-dev-20161201-31440-ndvdr6/build/tests/src/gui /tmp/qgis3-dev-20161201-31440-ndvdr6/build/tests/src/gui/CMakeFiles/qgis_keyvaluewidgettest.dir/DependInfo.cmake --color=
Scanning dependencies of target qgis_keyvaluewidgettest
sip: /usr/local/share/sip/Qt5/QtWidgets/qabstractbutton.sip:24: The struct/class has already been defined
make[2]: *** [python/gui/sip_guipart0.cpp] Error 1
make[2]: *** Deleting file `python/gui/sip_guipart0.cpp'
make[1]: *** [python/CMakeFiles/python_module_qgis__gui.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```