### PR TITLE
CMake setup: fall back to unix make if ninja is not available.

### DIFF
--- a/scripts/qgis-cmake-setup.sh
+++ b/scripts/qgis-cmake-setup.sh
@@ -48,7 +48,7 @@ if ! [[ "$INSTALL_DIR" = /* ]] || ! [ -d "$INSTALL_DIR" ]; then
   usage
 fi
 
-if ! (command -v cmake >/dev/null 2>&1); then
+if ! (which -s cmake); then
   echo "CMake executable 'cmake' not found in \$PATH"
   exit 1
 fi
@@ -78,7 +78,7 @@ rm -Rf $BUILD_DIR/*
 
 cd $BUILD_DIR
 
-if (command -v ninja >/dev/null 2>&1); then
+if (which -s ninja); then
   CMAKE_GENERATOR='Ninja'
 else
   CMAKE_GENERATOR='Unix\ Makefiles'

--- a/scripts/qgis-cmake-setup.sh
+++ b/scripts/qgis-cmake-setup.sh
@@ -24,7 +24,7 @@ set -e
 
 usage(){
   echo "usage: <script> 'source directory' 'build directory' 'install directory'"
-  echo "       (directories need to absolute paths)"
+  echo "       (directories must exist and be provided as absolute paths)"
   exit 1
 }
 
@@ -48,9 +48,8 @@ if ! [[ "$INSTALL_DIR" = /* ]] || ! [ -d "$INSTALL_DIR" ]; then
   usage
 fi
 
-CMAKE=$(which cmake)
-if [ -z $CMAKE ]; then
-  echo "CMake executable 'cmake' not found"
+if ! (command -v cmake >/dev/null 2>&1); then
+  echo "CMake executable 'cmake' not found in \$PATH"
   exit 1
 fi
 
@@ -79,8 +78,18 @@ rm -Rf $BUILD_DIR/*
 
 cd $BUILD_DIR
 
+if (command -v ninja >/dev/null 2>&1); then
+  CMAKE_GENERATOR='Ninja'
+else
+  CMAKE_GENERATOR='Unix\ Makefiles'
+fi
+
+echo "CMake generator: ${CMAKE_GENERATOR}"
+
 # cmake options
-cmd="${CMAKE} -G Ninja"
+cmd="cmake"
+
+cmd+=" -G ${CMAKE_GENERATOR}"
 cmd+=" -DCMAKE_INSTALL_PREFIX:PATH='${INSTALL_DIR}'"
 cmd+=" -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo"
 cmd+=" -DCMAKE_FIND_FRAMEWORK:STRING=LAST"


### PR DESCRIPTION
Be more flexible about chosing CMake generators.

This also fixes checking if `cmake` itself is available (the script would just fail silently if `which` failed).

I also took the liberty to clarify the message in `usage()`.