### PR TITLE
Add --without-python to install gdal2-python.

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -219,7 +219,7 @@ $HOMEBREW_PREFIX/opt/gdal2/bin/gdalinfo --formats
 $HOMEBREW_PREFIX/opt/gdal2/bin/ogrinfo --formats
 
 # Add the Python 3 bindings for GDAL/OGR
-brew install osgeo/osgeo4mac/gdal2-python --with-python3
+brew install osgeo/osgeo4mac/gdal2-python --with-python3 --without-python
 brew test osgeo/osgeo4mac/gdal2-python
 
 # Optionally add and verify Processing framework extra utilities


### PR DESCRIPTION
For some reason, I need to specify that I don't install it with python, but with python3. It doesn't work if I don't add `--without-python` option.