### PR TITLE
Remove missing variable in CMake configuration.

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -401,7 +401,6 @@ Under ``Kits`` tab, click ``Add``, then configure with:
 
   ```
   CMAKE_CXX_COMPILER:STRING=%{Compiler:Executable}
-  CMAKE_C_COMPILER:STRING=%{Compiler:Executable:C}
   QT_QMAKE_EXECUTABLE:STRING=%{Qt:qmakeExecutable}
   CMAKE_BUILD_TYPE:STRING=RelWithDebInfo
   CMAKE_FIND_FRAMEWORK:STRING=LAST 


### PR DESCRIPTION
I tried to follow the development README, but I got this error when tried to load QGIS project:
```
Running "/usr/local/bin/cmake /Users/ismailsunni/dev/cpp/QGIS '-GCodeBlocks - Unix Makefiles' -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DCMAKE_CXX_COMPILER:STRING=/usr/local/opt/ccache/libexec/clang++ '-DCMAKE_C_COMPILER:STRING=%{Compiler:Executable:C}' '-DCMAKE_FIND_FRAMEWORK:STRING=LAST ' '-DCMAKE_PREFIX_PATH:STRING='\''/usr/local/opt/qt5;/usr/local/opt/qt5-webkit;/usr/local/opt/qscintilla2;/usr/local/opt/qwt;/usr/local/opt/qwtpolar;/usr/local/opt/qca;/usr/local/opt/gdal2;/usr/local/opt/gsl;/usr/local/opt/geos;/usr/local/opt/proj;/usr/local/opt/libspatialite;/usr/local/opt/spatialindex;/usr/local/opt/fcgi;/usr/local/opt/expat;/usr/local/opt/sqlite;/usr/local/opt/flex;/usr/local/opt/bison'\''' -DQT_QMAKE_EXECUTABLE:STRING=/usr/local/Cellar/qt5/5.8.0_1/bin/qmake" in /var/folders/h7/k16m33695_g2ptlzy0z8vxb00000gp/T/qtc-cmake-oHpJFt.
-- The C compiler identification is unknown
-- The CXX compiler identification is AppleClang 8.0.0.8000042
CMake Error at CMakeLists.txt:10 (PROJECT):
  The CMAKE_C_COMPILER:

    %{Compiler:Executable:C}

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
  the compiler, or to the compiler name if it is in the PATH.


-- Check for working CXX compiler: /usr/local/opt/ccache/libexec/clang++
-- Check for working CXX compiler: /usr/local/opt/ccache/libexec/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring incomplete, errors occurred!
See also "/private/var/folders/h7/k16m33695_g2ptlzy0z8vxb00000gp/T/qtc-cmake-oHpJFt/CMakeFiles/CMakeOutput.log".
See also "/private/var/folders/h7/k16m33695_g2ptlzy0z8vxb00000gp/T/qtc-cmake-oHpJFt/CMakeFiles/CMakeError.log".
*** cmake process exited with exit code 1.
```
It seems it couldn't find the variable of `%{Compiler:Executable:C}`. After I remove the line, I able to load the project.