### PR TITLE
Updated deprecated homebrew/science/matplotlib

### DIFF
--- a/Formula/qgis3-dev.rb
+++ b/Formula/qgis3-dev.rb
@@ -83,7 +83,7 @@ class Qgis3Dev < Formula
   depends_on "expat" # keg_only
   depends_on "proj"
   depends_on "spatialindex"
-  depends_on "homebrew/science/matplotlib"
+  depends_on "brewsci/science/matplotlib"
   depends_on "fcgi" if build.with? "server"
   # use newer postgresql client than Apple's, also needed by `psycopg2`
   depends_on "postgresql" => :recommended


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-science is now deprecated updated with new tap