### PR TITLE
Update qgis3-dev.rb

### DIFF
--- a/Formula/qgis3-dev.rb
+++ b/Formula/qgis3-dev.rb
@@ -66,7 +66,7 @@ class Qgis3Dev < Formula
     depends_on "doxygen"
   end
 
-  depends_on :python3
+  depends_on "python3"
 
   depends_on "qt" # keg_only
   depends_on "osgeo/osgeo4mac/qt5-webkit" => :recommended # keg_only


### PR DESCRIPTION
Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python3"' instead.
/usr/local/Homebrew/Library/Taps/qgis/homebrew-qgisdev/Formula/qgis3-dev.rb:69:in `<class:Qgis3Dev>'
Please report this to the qgis/qgisdev tap!