### PR TITLE
Update qgis3-dev.rb

### DIFF
--- a/Formula/qgis3-dev.rb
+++ b/Formula/qgis3-dev.rb
@@ -518,14 +518,14 @@ class Qgis3Dev < Formula
       For standalone Python3 development, set the following environment variable:
         export PYTHONPATH=#{qgis_python_packages}:#{gdal_python_packages}:#{python_site_packages}:$PYTHONPATH
 
-    EOS
+    <<~EOS
 
     s += <<-EOS.undent
       If you have built GRASS 7 for the Processing plugin set the following in QGIS:
         Processing->Options: Providers->GRASS GIS 7 commands->GRASS 7 folder to:
            #{HOMEBREW_PREFIX}/opt/grass7/grass-base
 
-    EOS
+    <<~EOS
 
     s
   end


### PR DESCRIPTION
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/qgis/homebrew-qgisdev/Formula/qgis3-dev.rb:521:in `caveats'
Please report this to the qgis/qgisdev tap!

Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/qgis/homebrew-qgisdev/Formula/qgis3-dev.rb:528:in `caveats'
Please report this to the qgis/qgisdev tap!